### PR TITLE
Mehrere Fehler bei den Details verbessert

### DIFF
--- a/entitygraph/__init__.py
+++ b/entitygraph/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 from entitygraph.admin import Admin
 from entitygraph.base_client import BaseApiClient

--- a/entitygraph/application.py
+++ b/entitygraph/application.py
@@ -30,7 +30,7 @@ def save_detail(entity_id: str, detail: entitygraph.Detail):
         'POST',
         f'api/entities/{entity_id}/values/{detail.value_predicate}/details/{detail.predicate}',
         headers=headers,
-        data=detail.content.encode('utf-8'),
+        data=json.dumps(detail.content) if isinstance(detail.content, dict) else str(detail.content).encode('utf-8'),
         params=params
     )
     response.raise_for_status()
@@ -258,7 +258,8 @@ class Application:
                     if detail.has_changes():
                         if detail.remove_old:
                             delete_detail(new_entity_id, detail)
-                        save_detail(new_entity_id, detail)
+                        if detail.content:
+                            save_detail(new_entity_id, detail)
 
         entity.add_id(new_entity_id)
 
@@ -357,7 +358,8 @@ class Application:
                     if detail.has_changes():
                         if detail.remove_old:
                             delete_detail(entity.id, detail)
-                        save_detail(entity.id, detail)
+                        if detail.content:
+                            save_detail(entity.id, detail)
 
         return entity
 

--- a/entitygraph/entity/container/icontainer.py
+++ b/entitygraph/entity/container/icontainer.py
@@ -57,13 +57,6 @@ class IContainerAbstract(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def content_lst(self) -> list:
-        """A private method that returns all content.
-        """
-
-        raise NotImplementedError()
-
-    @abstractmethod
     def has_changes(self) -> bool:
         """Indicates, that this classes data has been updated.
         """


### PR DESCRIPTION
 - Ein Fehler wurde korregiert, der dazu führte, dass Details in manchen Fällen nicht richtig gelöscht worden sind.
 - Die Funktion "remove_content" der Details-Klasse wirft nun einen Fehler, falls kein Kontent existiert. Es wurde der Keyword-Parameter "raise_error_if_not_exists" ergänzt, der auf False gesetzt werden kann (default ist True), wenn kein Error geworfen werden soll.
 - Es wurde ein Fehler behoben, der dazu führte, dass Details mit leerem Kontent bei Aufrufen der "content" Property fälschlicherweise einen Error geworfen haben.
 - Der Inhalt eines Details kann nun korrekterweise auch ein (JSON-)Objekt sein.
 - Known Issue: Beim Speichern von Details als (JSON-)Objekt werden int/float/boolean Werte in strings konvertiert.
 - Die Property "content_lst" wurde bei Details entfernt, da sie überflüssig war.